### PR TITLE
show users talks in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,20 @@ DATABASE_URL = postgres://<user_name>:<password>@localhost:5432/<database_name>
 
 ### File Structure
 
-📁 public - all publicly hosted files
+- 📁 **public** (all publicly hosted files)
     - includes client side js, css, images, and sounds
 
-📁 src - all server side files  
-    📁 controllers  
+- 📁 **src** (all server side files)   
+    - ↳ 📁 **controllers**  
         ↳ data processing functions that don't interact directly with the database, or rendering system  
-    📁 database  
+    - ↳ 📁 **database**  
         ↳ database schema, build, and connection scripts, and queries that interact directly with the database  
-    📁 routes  
+    - ↳ 📁 **routes**  
         ↳ handles the processing of data for different routes (GET and POST requests)  
-    📁 views  
+    - ↳ 📁 **views**  
         ↳ handlebars(.hbs) files that implement server side rendering  
 
-📁 tests - all tests (run with tape)
+- 📁 **tests** (all tests)
 
 
 ---

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -269,6 +269,11 @@ a {
       padding: 0 2rem; } }
   .main-section:first-child {
     text-align: center; }
+  .dashboard .main-section:not(:first-child):not(:last-child) {
+    padding-top: 1rem;
+    padding-bottom: 3rem;
+    margin-bottom: 2rem;
+    border-bottom: 2px solid white; }
 
 .page-content .main-section:first-child {
   margin-top: 6rem; }

--- a/public/js/search-talks.js
+++ b/public/js/search-talks.js
@@ -9,7 +9,6 @@ This file requires dom-helpers.js to work
 - fetch data at the end of the file
 
 To Do:
-- grey out past talks
 - get sort button working with past and future talks (integration)
 */
 

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -81,6 +81,16 @@ a {
     &:first-child {
         text-align: center;
     }
+    // page specific
+    &:not(:first-child):not(:last-child) {
+        .dashboard & {
+            padding-top: 1rem;
+            padding-bottom: 3rem;
+            margin-bottom: 2rem;
+            border-bottom: 2px solid $white;
+        }
+    }
+    
 }
 // only applies to sections within <main>
 .page-content .main-section:first-child {

--- a/src/database/db_helpers/checkPassword.js
+++ b/src/database/db_helpers/checkPassword.js
@@ -24,9 +24,6 @@ const checkPassword = userDetails => {
   
         // 3.
         else {
-          // console.log(res.rows[0].password);
-
-          // might want this to be in a promise - this and addUser.js fail on heroku
 
           bcrypt.compare(password, res.rows[0].password,
             (err, passwordsMatch) => {
@@ -43,7 +40,6 @@ const checkPassword = userDetails => {
               
               // success
               else {
-                // console.log(passwordsMatch);
                 resolve(passwordsMatch);
               }
   

--- a/src/database/db_helpers/getUserId.js
+++ b/src/database/db_helpers/getUserId.js
@@ -8,7 +8,7 @@ const getUserId = userName => {
         [userName],
         (err, res) => {
             if (err) {
-                reject('no id for user found in the database ', err);
+                reject(err);
             }
             else {
                 resolve(res.rows[0].id);

--- a/src/database/sql/db_build.sql
+++ b/src/database/sql/db_build.sql
@@ -25,4 +25,5 @@ CREATE TABLE talks (
   node BOOLEAN NOT NULL
 );
 
+
 COMMIT;

--- a/src/database/sql/test_db_build.sql
+++ b/src/database/sql/test_db_build.sql
@@ -67,7 +67,7 @@ INSERT INTO talks (user_id, subject, datetime, html, css, js, sql, node) VALUES
 ),
 (
   2, 
-  'Database testing',
+  'Database Testing',
   '2019-01-10 13:00:00',
   false,
   false,

--- a/src/routes/addTalk.js
+++ b/src/routes/addTalk.js
@@ -37,6 +37,8 @@ const addTalk = (req, res) => {
     db_helpers.getUserId(userName)
         .then(id => {
 
+            console.log(id);
+
             // 3.
             // need to do a better job with the timestamp, it is not sortable on the frontend
             // - this could be due to the sorting function, not necessarily timestamp formatting

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -102,26 +102,20 @@ router.get("/login", (req, res) => {
 // - used for checkboxes
 const languages = ['html', 'css', 'js', 'sql', 'node'];
 router.get("/dashboard", (req, res) => {
-  
 
-
-  // logged in
-  // - detect who the user is on login or signup
-  // a) decrypt cookie - tried this below
-  // b) pass form details to the dashboard route somehow
-
-  // - should I check more than just 'jwt' in a cookie?
-  // - can jwt be decrypted and matched to a particular user? I don't think so
-  // - undefined = does not interfere with tests:
-
+  // must have a cookie to view the dashboard
   if (req.headers.cookie !== undefined && req.headers.cookie.includes('jwt')) {
 
-    const myJwt = req.headers.cookie.split(' ').find(cookie => cookie.includes('jwt'));
+    // can't seem to decrypt the cookie here - get jwt is malformed error
+    const myJwt = req.headers.cookie.split(' ').find(cookie => cookie.includes('lightningJwt'));
+    // const jwt = verify(req.headers.cookie, secret);
+    // console.log(myJwt);
+    // const payload = myJwt.split('.')[1];
+    // console.log(payload);
+    // const answer = verify(payload, secret);
+    // console.log(answer);
 
-    
-    // create a GET request to get the talks when the browser lands on the dashboard
-    // - probably not here, as this is the initial render
-    // - cookie created before the initial render
+
 
     // render dashboard and button state
     res.render("dashboard", { languages: languages, loginButtons: status} );
@@ -174,7 +168,7 @@ router.post("/addtalk", (req, res) => {
 
 // ___________________________________
 // error pages
-router.use(function(req, res, next) {
+router.use((req, res, next) => {
   res.status(404);
 
   const status = controllers.loginButtons(req);

--- a/src/views/dashboard.hbs
+++ b/src/views/dashboard.hbs
@@ -6,8 +6,7 @@
     </section>
 
     <section class="main-section" id="add-talk">
-        <h2>Add Talk</h2>
-        <p>Cookie / whatever should identify user, and add correct _user_ info to the database this way</p>
+        <h2>Add Talk +</h2>
         <form class="form main-form" id="add-talk-form" method="/post" action="/addtalk">
 
             <label for="subject">Subject</label>
@@ -44,25 +43,12 @@
     <section class="main-section" id="your-talks">
         <h3>Your Talks</h3>
         <p id="success-message"></p>
-        <p>if user has talks, show list of talks, with edit talk button, to go to edit talk page/ section</p>
-        <p>if user has no talks, say they have no talks, CTA to add a talk</p>
-        <!--
-            if no talks found for user:
-                You have contributed no talks yet, add your talk above
-            else
-                display all talks    
-        -->
+        {{!-- <button class="button-input has-icon" id="talk-btn"><a href="/#">Your Talks <span class="button-icon">v</span></a></button> --}}
+        <ul class="talks-list"></ul>
+
     </section>
-    <section class="main-section" id="your-talks">
+    <section class="main-section" id="bookmarked-talks">
         <h3>Bookmarked Talks</h3>
-        <p>Show list partial, with bookmarked talks</p>
-        <p>if no talks are bookmarked, CTA to bookmark a talk</p>
-        <!--
-            if no bookmarks found for user:
-                You have no bookmarks yet, bookmark talks here (link to view-talks) - show bookmark option when logged in
-            else
-                display all talks bookmarked by user  
-        -->
     </section>
 </main>
 <audio class="thunder-success" src="sounds/thunder_sound.mp3"></audio>

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -85,17 +85,17 @@ test("upcomingTalks function fails: date is past any future talks", t => {
   });
 });
 // passing
-test("upcomingTalks function passes: first subject is 'Database testing'", t => {
+test("upcomingTalks function passes: first subject is 'React'", t => {
   testBuild((error, response) => {
     if (error) {
       console.log("testBuild error: ", error);
     } else {
-      db_helpers.upcomingTalks('2019-01-02 20:00:00')
+      db_helpers.upcomingTalks('2019-01-14 17:30:0')
         .then(res => {
           t.deepEqual(
             res[0].subject,
-            "Database testing",
-            "The next subject of the next talk (as of 02/01/2019) should be 'Database testing'"
+            "React",
+            "The next subject of the next talk (as of 2019-01-14) should be 'React'"
           );
           t.end();
         })


### PR DESCRIPTION
- Updated heroku database - previous version had a null user id for one entry which could have been causing problems. Possibly a problem with test build script, which seems to create this.
- Render the talks by decrypting the cookie on the frontend, and calling the search api. Can't work out how to do this on the backend still.
- Talks are rendered on load
- Next, should probably refactor, as repeated code is building up
- Edit talk functionality is required too.